### PR TITLE
chore: disable renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false
+}


### PR DESCRIPTION
## Summary
- Disables Renovatebot by adding `renovate.json` with `"enabled": false`
- This repo is a fork of `bazel-contrib/rules_oci` — dependency updates should be managed upstream, not on the fork. Running Renovatebot here creates noise with PRs that will never be merged since this fork should stay in sync with upstream.